### PR TITLE
feat: Add live reload, input validation, LICENSE and README updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,10 @@ unicode-width = "0.1"
 atty = "0.2"
 
 # HTTP server for browser mode
-axum = "0.7"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+axum = { version = "0.7", features = ["ws"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
+tokio-tungstenite = "0.24"
+futures-util = "0.3"
 tower-http = { version = "0.5", features = ["fs", "cors"] }
 
 # Browser opening
@@ -36,6 +38,10 @@ open = "5"
 
 # HTML escaping
 html-escape = "0.2"
+
+# File watching
+notify = "6"
+notify-debouncer-mini = "0.4"
 
 [profile.release]
 opt-level = 3

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 sora-grayscale
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ A rich Markdown previewer for the terminal and browser, written in Rust.
 - Inline code highlighting
 - Automatic paging with less
 
+### Browser Mode
+- GitHub-style rendering with CSS
+- Live reload on file changes
+- Syntax highlighting (powered by highlight.js)
+
 ### Planned Features
-- Browser mode with live reload
-- File watching for auto-refresh
+- Directory mode with file navigation
 - KaTeX math rendering
 - Mermaid diagram support
 - Image display (iTerm2/Kitty protocol)
 - Table of contents generation
-- Theme customization (dark/light)
 
 ## Installation
 
@@ -38,8 +41,14 @@ sudo cp target/release/mdp /usr/local/bin/
 ## Usage
 
 ```bash
-# Basic usage
+# Basic usage (terminal)
 mdp README.md
+
+# Browser mode
+mdp -b README.md
+
+# Browser mode with live reload
+mdp -bw README.md
 
 # Disable pager (output directly)
 mdp --no-pager README.md
@@ -55,11 +64,12 @@ mdp --help
 
 | Option | Description |
 |--------|-------------|
-| `-w, --watch` | Watch for file changes (not yet implemented) |
-| `-b, --browser` | Open in browser (not yet implemented) |
-| `--toc` | Show table of contents (not yet implemented) |
+| `-b, --browser` | Open in browser with GitHub-style rendering |
+| `-w, --watch` | Watch for file changes and auto-reload |
+| `-p, --port <PORT>` | Port for browser mode (default: 3000) |
 | `--theme <THEME>` | Theme: dark or light (default: dark) |
 | `--no-pager` | Disable pager, output directly to stdout |
+| `--toc` | Show table of contents (not yet implemented) |
 
 ## Requirements
 
@@ -67,6 +77,15 @@ mdp --help
 - A terminal with 24-bit color support (recommended)
 - `less` or another pager (optional)
 
+## Similar Projects
+
+- [glow](https://github.com/charmbracelet/glow) - Render markdown on the CLI (Go)
+- [mdcat](https://github.com/swsnr/mdcat) - cat for markdown (Rust)
+- [grip](https://github.com/joeyespo/grip) - GitHub Readme Instant Preview (Python)
+- [bat](https://github.com/sharkdp/bat) - A cat clone with syntax highlighting (Rust)
+- [rich-cli](https://github.com/Textualize/rich-cli) - Fancy output in the terminal (Python)
+
 ## License
 
 MIT
+

--- a/assets/template.html
+++ b/assets/template.html
@@ -7,11 +7,88 @@
     <link rel="stylesheet" href="/assets/github.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-    <script>hljs.highlightAll();</script>
+    <style>
+        .reload-indicator {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            padding: 8px 16px;
+            background: #28a745;
+            color: white;
+            border-radius: 4px;
+            font-size: 12px;
+            opacity: 0;
+            transition: opacity 0.3s;
+            z-index: 9999;
+        }
+        .reload-indicator.show {
+            opacity: 1;
+        }
+        .reload-indicator.disconnected {
+            background: #dc3545;
+        }
+    </style>
 </head>
 <body>
+    <div id="reload-indicator" class="reload-indicator">Connected</div>
     <div class="markdown-body">
         {{CONTENT}}
     </div>
+    <script>
+        hljs.highlightAll();
+
+        // WebSocket for live reload
+        (function() {
+            const indicator = document.getElementById('reload-indicator');
+            let ws;
+            let reconnectAttempts = 0;
+            const maxReconnectAttempts = 10;
+
+            function showIndicator(message, isError) {
+                indicator.textContent = message;
+                indicator.classList.toggle('disconnected', isError);
+                indicator.classList.add('show');
+                setTimeout(() => {
+                    indicator.classList.remove('show');
+                }, 2000);
+            }
+
+            function connect() {
+                const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+                const wsUrl = `${protocol}//${window.location.host}/ws`;
+                ws = new WebSocket(wsUrl);
+
+                ws.onopen = function() {
+                    reconnectAttempts = 0;
+                    showIndicator('Connected', false);
+                };
+
+                ws.onmessage = function(event) {
+                    if (event.data === 'reload') {
+                        showIndicator('Reloading...', false);
+                        setTimeout(() => {
+                            window.location.reload();
+                        }, 100);
+                    }
+                };
+
+                ws.onclose = function() {
+                    if (reconnectAttempts < maxReconnectAttempts) {
+                        reconnectAttempts++;
+                        showIndicator(`Reconnecting (${reconnectAttempts})...`, true);
+                        setTimeout(connect, 1000 * Math.min(reconnectAttempts, 5));
+                    } else {
+                        showIndicator('Disconnected', true);
+                    }
+                };
+
+                ws.onerror = function() {
+                    ws.close();
+                };
+            }
+
+            connect();
+        })();
+    </script>
 </body>
 </html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod parser;
 pub mod renderer;
 pub mod server;
+pub mod watcher;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,33 +1,68 @@
 use axum::{
-    extract::State,
-    http::{header, StatusCode},
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    http::{header, HeaderMap, StatusCode},
     response::{Html, IntoResponse, Response},
     routing::get,
     Router,
 };
+use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::broadcast;
 
 use crate::renderer::html::HtmlRenderer;
+use crate::watcher::watch_file_async;
 
 pub struct ServerState {
-    pub html_content: String,
+    pub markdown_path: PathBuf,
+    pub title: String,
+    pub reload_tx: broadcast::Sender<()>,
 }
 
-pub async fn start_server(markdown: &str, title: &str, port: u16) -> std::io::Result<()> {
-    let renderer = HtmlRenderer::new(title);
-    let html_content = renderer.render(markdown);
+impl ServerState {
+    fn render_html(&self) -> String {
+        let content = std::fs::read_to_string(&self.markdown_path).unwrap_or_default();
+        let renderer = HtmlRenderer::new(&self.title);
+        renderer.render(&content)
+    }
+}
 
-    let state = Arc::new(ServerState { html_content });
+pub async fn start_server(markdown_path: PathBuf, title: &str, port: u16, watch: bool) -> std::io::Result<()> {
+    let (reload_tx, _) = broadcast::channel::<()>(16);
+
+    let state = Arc::new(ServerState {
+        markdown_path: markdown_path.clone(),
+        title: title.to_string(),
+        reload_tx: reload_tx.clone(),
+    });
+
+    // Start file watcher if watch mode is enabled
+    if watch {
+        let watch_tx = reload_tx.clone();
+        let watch_path = markdown_path.clone();
+        tokio::spawn(async move {
+            if let Err(e) = watch_file_async(&watch_path, watch_tx).await {
+                eprintln!("Failed to start file watcher: {}", e);
+            }
+        });
+    }
 
     let app = Router::new()
         .route("/", get(serve_html))
         .route("/assets/github.css", get(serve_css))
+        .route("/ws", get(ws_handler))
         .with_state(state);
 
     let addr = format!("127.0.0.1:{}", port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
 
     println!("Server running at http://{}", addr);
+    if watch {
+        println!("Live reload enabled - changes will auto-refresh");
+    }
+    println!("Press Ctrl+C to stop");
 
     // Open browser
     if let Err(e) = open::that(format!("http://{}", addr)) {
@@ -40,8 +75,10 @@ pub async fn start_server(markdown: &str, title: &str, port: u16) -> std::io::Re
     Ok(())
 }
 
-async fn serve_html(State(state): State<Arc<ServerState>>) -> Html<String> {
-    Html(state.html_content.clone())
+async fn serve_html(State(state): State<Arc<ServerState>>) -> (HeaderMap, Html<String>) {
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CACHE_CONTROL, "no-store".parse().unwrap());
+    (headers, Html(state.render_html()))
 }
 
 async fn serve_css() -> Response {
@@ -51,6 +88,49 @@ async fn serve_css() -> Response {
         HtmlRenderer::get_css(),
     )
         .into_response()
+}
+
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<ServerState>>,
+) -> Response {
+    ws.on_upgrade(move |socket| handle_socket(socket, state))
+}
+
+async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
+    let mut rx = state.reload_tx.subscribe();
+
+    // Send initial connection confirmation
+    let _ = socket.send(Message::Text("connected".to_string())).await;
+
+    loop {
+        tokio::select! {
+            // Wait for reload signal
+            result = rx.recv() => {
+                match result {
+                    Ok(_) => {
+                        // Send reload signal to client
+                        if socket.send(Message::Text("reload".to_string())).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            // Handle incoming messages (for ping/pong)
+            msg = socket.recv() => {
+                match msg {
+                    Some(Ok(Message::Ping(data))) => {
+                        if socket.send(Message::Pong(data)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => break,
+                    _ => {}
+                }
+            }
+        }
+    }
 }
 
 /// Find an available port starting from the given port

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,0 +1,102 @@
+use notify::RecursiveMode;
+use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
+use std::path::Path;
+use std::sync::mpsc::channel;
+use std::time::Duration;
+use tokio::sync::broadcast;
+
+/// Watch a file for changes and send notifications
+pub fn watch_file<P: AsRef<Path>>(
+    path: P,
+    tx: broadcast::Sender<()>,
+) -> notify::Result<()> {
+    let path = path.as_ref().to_path_buf();
+    let (debounce_tx, debounce_rx) = channel();
+
+    // Create a debouncer with 200ms delay
+    let mut debouncer = new_debouncer(Duration::from_millis(200), debounce_tx)?;
+
+    // Watch the file
+    debouncer.watcher().watch(&path, RecursiveMode::NonRecursive)?;
+
+    println!("Watching for changes: {}", path.display());
+
+    // Process events
+    loop {
+        match debounce_rx.recv() {
+            Ok(Ok(events)) => {
+                for event in events {
+                    if event.kind == DebouncedEventKind::Any {
+                        println!("File changed, reloading...");
+                        let _ = tx.send(());
+                    }
+                }
+            }
+            Ok(Err(e)) => {
+                eprintln!("Watch error: {:?}", e);
+            }
+            Err(e) => {
+                eprintln!("Channel error: {:?}", e);
+                break;
+            }
+        }
+    }
+
+    // Keep debouncer alive
+    drop(debouncer);
+    Ok(())
+}
+
+/// Watch a file asynchronously using tokio
+pub async fn watch_file_async<P: AsRef<Path>>(
+    path: P,
+    tx: broadcast::Sender<()>,
+) -> notify::Result<()> {
+    let path = path.as_ref().to_path_buf();
+
+    println!("Watching for changes: {}", path.display());
+
+    // Spawn blocking task for file watching - debouncer must live inside the blocking task
+    tokio::task::spawn_blocking(move || {
+        let (debounce_tx, debounce_rx) = channel();
+
+        // Create a debouncer with 200ms delay
+        let mut debouncer = match new_debouncer(Duration::from_millis(200), debounce_tx) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("Failed to create debouncer: {}", e);
+                return;
+            }
+        };
+
+        // Watch the file
+        if let Err(e) = debouncer.watcher().watch(&path, RecursiveMode::NonRecursive) {
+            eprintln!("Failed to watch file: {}", e);
+            return;
+        }
+
+        loop {
+            match debounce_rx.recv() {
+                Ok(Ok(events)) => {
+                    for event in events {
+                        if event.kind == DebouncedEventKind::Any {
+                            println!("File changed, reloading...");
+                            let _ = tx.send(());
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    eprintln!("Watch error: {:?}", e);
+                }
+                Err(_) => {
+                    break;
+                }
+            }
+        }
+
+        // Keep debouncer alive until loop exits
+        drop(debouncer);
+    });
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Phase 4: ブラウザモードでのライブリロード (WebSocket)
- ファイルウォッチャー (notify crate + debouncing)
- 入力バリデーション強化 (ディレクトリ、非.mdファイル)
- MITライセンスファイル追加
- README更新 (実装済み機能、Similar Projects)
- Cache-Controlヘッダー追加

## Changes
- `src/watcher.rs` - 新規: ファイル監視モジュール
- `src/server.rs` - WebSocket対応、キャッシュヘッダー追加
- `src/main.rs` - 入力バリデーション追加
- `assets/template.html` - WebSocketクライアント追加
- `LICENSE` - MIT License
- `README.md` - 機能説明更新

## Test
```bash
# ライブリロード
mdp -bw README.md

# ディレクトリ入力
mdp .  # エラーメッセージ表示

# 非.mdファイル
mdp Cargo.toml  # 警告表示
```