### PR TITLE
feat: Directory mode with sidebar navigation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,19 @@ html-escape = "0.2"
 notify = "6"
 notify-debouncer-mini = "0.4"
 
+# Directory traversal
+walkdir = "2"
+
+# JSON serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Regex for link processing
+regex = "1"
+
+[dev-dependencies]
+tempfile = "3"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/assets/template_sidebar.html
+++ b/assets/template_sidebar.html
@@ -1,0 +1,276 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{TITLE}}</title>
+    <link rel="stylesheet" href="/assets/github.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: hidden;
+        }
+        .container {
+            display: flex;
+            height: 100vh;
+        }
+        .sidebar {
+            width: 250px;
+            min-width: 200px;
+            max-width: 400px;
+            background: #f6f8fa;
+            border-right: 1px solid #d0d7de;
+            overflow-y: auto;
+            padding: 16px 0;
+            flex-shrink: 0;
+        }
+        .sidebar-header {
+            padding: 0 16px 12px;
+            font-weight: 600;
+            font-size: 14px;
+            color: #24292f;
+            border-bottom: 1px solid #d0d7de;
+            margin-bottom: 8px;
+        }
+        .sidebar-folder {
+            padding: 6px 16px;
+            font-size: 12px;
+            color: #57606a;
+            font-weight: 500;
+            margin-top: 8px;
+        }
+        .sidebar-item {
+            display: block;
+            padding: 8px 16px 8px 24px;
+            color: #24292f;
+            text-decoration: none;
+            font-size: 14px;
+            cursor: pointer;
+            border-left: 3px solid transparent;
+        }
+        .sidebar-item:hover {
+            background: #eaeef2;
+        }
+        .sidebar-item.active {
+            background: #ddf4ff;
+            border-left-color: #0969da;
+            font-weight: 500;
+        }
+        .main-content {
+            flex: 1;
+            overflow-y: auto;
+            padding: 32px 48px;
+            max-width: 100%;
+        }
+        .markdown-body {
+            max-width: 980px;
+            margin: 0 auto;
+        }
+        .reload-indicator {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            padding: 8px 16px;
+            background: #28a745;
+            color: white;
+            border-radius: 4px;
+            font-size: 12px;
+            opacity: 0;
+            transition: opacity 0.3s;
+            z-index: 9999;
+        }
+        .reload-indicator.show {
+            opacity: 1;
+        }
+        .reload-indicator.disconnected {
+            background: #dc3545;
+        }
+        /* Resizer */
+        .resizer {
+            width: 4px;
+            background: transparent;
+            cursor: col-resize;
+            flex-shrink: 0;
+        }
+        .resizer:hover {
+            background: #0969da;
+        }
+        /* Dark mode support */
+        @media (prefers-color-scheme: dark) {
+            .sidebar {
+                background: #161b22;
+                border-right-color: #30363d;
+            }
+            .sidebar-header {
+                color: #c9d1d9;
+                border-bottom-color: #30363d;
+            }
+            .sidebar-folder {
+                color: #8b949e;
+            }
+            .sidebar-item {
+                color: #c9d1d9;
+            }
+            .sidebar-item:hover {
+                background: #21262d;
+            }
+            .sidebar-item.active {
+                background: #388bfd26;
+                border-left-color: #58a6ff;
+            }
+            .main-content {
+                background: #0d1117;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div id="reload-indicator" class="reload-indicator">Connected</div>
+    <div class="container">
+        <div class="sidebar">
+            <div class="sidebar-header">📂 {{TITLE}}</div>
+            {{SIDEBAR}}
+        </div>
+        <div class="resizer" id="resizer"></div>
+        <div class="main-content">
+            <div class="markdown-body" id="content">
+                {{CONTENT}}
+            </div>
+        </div>
+    </div>
+    <script>
+        hljs.highlightAll();
+
+        // Current file path
+        let currentFile = null;
+
+        // Load file via AJAX
+        async function loadFile(path) {
+            try {
+                const response = await fetch('/api/content?file=' + encodeURIComponent(path));
+                if (!response.ok) throw new Error('File not found');
+
+                const html = await response.text();
+                document.getElementById('content').innerHTML = html;
+
+                // Update active state in sidebar
+                document.querySelectorAll('.sidebar-item').forEach(item => {
+                    item.classList.toggle('active', item.dataset.path === path);
+                });
+
+                // Update URL without reload
+                const url = new URL(window.location);
+                url.searchParams.set('file', path);
+                history.pushState({file: path}, '', url);
+
+                // Update current file
+                currentFile = path;
+
+                // Re-highlight code blocks
+                hljs.highlightAll();
+            } catch (e) {
+                console.error('Failed to load file:', e);
+            }
+        }
+
+        // Handle browser back/forward
+        window.addEventListener('popstate', (event) => {
+            if (event.state && event.state.file) {
+                loadFile(event.state.file);
+            }
+        });
+
+        // Initialize current file from URL
+        const urlParams = new URLSearchParams(window.location.search);
+        currentFile = urlParams.get('file');
+
+        // Resizer functionality
+        const resizer = document.getElementById('resizer');
+        const sidebar = document.querySelector('.sidebar');
+        let isResizing = false;
+
+        resizer.addEventListener('mousedown', (e) => {
+            isResizing = true;
+            document.body.style.cursor = 'col-resize';
+            document.body.style.userSelect = 'none';
+        });
+
+        document.addEventListener('mousemove', (e) => {
+            if (!isResizing) return;
+            const newWidth = e.clientX;
+            if (newWidth >= 150 && newWidth <= 500) {
+                sidebar.style.width = newWidth + 'px';
+            }
+        });
+
+        document.addEventListener('mouseup', () => {
+            isResizing = false;
+            document.body.style.cursor = '';
+            document.body.style.userSelect = '';
+        });
+
+        // WebSocket for live reload
+        (function() {
+            const indicator = document.getElementById('reload-indicator');
+            let ws;
+            let reconnectAttempts = 0;
+            const maxReconnectAttempts = 10;
+
+            function showIndicator(message, isError) {
+                indicator.textContent = message;
+                indicator.classList.toggle('disconnected', isError);
+                indicator.classList.add('show');
+                setTimeout(() => {
+                    indicator.classList.remove('show');
+                }, 2000);
+            }
+
+            function connect() {
+                const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+                const wsUrl = `${protocol}//${window.location.host}/ws`;
+                ws = new WebSocket(wsUrl);
+
+                ws.onopen = function() {
+                    reconnectAttempts = 0;
+                    showIndicator('Connected', false);
+                };
+
+                ws.onmessage = function(event) {
+                    if (event.data === 'reload') {
+                        showIndicator('Reloading...', false);
+                        // Reload current file content instead of full page reload
+                        if (currentFile) {
+                            loadFile(currentFile);
+                        } else {
+                            window.location.reload();
+                        }
+                    }
+                };
+
+                ws.onclose = function() {
+                    if (reconnectAttempts < maxReconnectAttempts) {
+                        reconnectAttempts++;
+                        showIndicator(`Reconnecting (${reconnectAttempts})...`, true);
+                        setTimeout(connect, 1000 * Math.min(reconnectAttempts, 5));
+                    } else {
+                        showIndicator('Disconnected', true);
+                    }
+                };
+
+                ws.onerror = function() {
+                    ws.close();
+                };
+            }
+
+            connect();
+        })();
+    </script>
+</body>
+</html>

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,0 +1,150 @@
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Represents a markdown file with its relative path
+#[derive(Debug, Clone)]
+pub struct MarkdownFile {
+    /// Absolute path to the file
+    pub absolute_path: PathBuf,
+    /// Relative path from the base directory
+    pub relative_path: PathBuf,
+    /// Display name (filename without extension)
+    pub name: String,
+}
+
+/// Represents a directory structure of markdown files
+#[derive(Debug, Clone)]
+pub struct FileTree {
+    /// Base directory path
+    pub base_path: PathBuf,
+    /// All markdown files found
+    pub files: Vec<MarkdownFile>,
+}
+
+impl FileTree {
+    /// Create a FileTree from a directory path
+    pub fn from_directory(path: &Path) -> std::io::Result<Self> {
+        let base_path = path.canonicalize()?;
+        let mut files = Vec::new();
+
+        for entry in WalkDir::new(&base_path)
+            .follow_links(true)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let entry_path = entry.path();
+
+            // Skip directories and non-markdown files
+            if entry_path.is_dir() {
+                continue;
+            }
+
+            if let Some(ext) = entry_path.extension() {
+                if ext == "md" || ext == "markdown" {
+                    let relative_path = entry_path
+                        .strip_prefix(&base_path)
+                        .unwrap_or(entry_path)
+                        .to_path_buf();
+
+                    let name = entry_path
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("untitled")
+                        .to_string();
+
+                    files.push(MarkdownFile {
+                        absolute_path: entry_path.to_path_buf(),
+                        relative_path,
+                        name,
+                    });
+                }
+            }
+        }
+
+        // Sort files: README first, then alphabetically
+        files.sort_by(|a, b| {
+            let a_is_readme = a.name.to_lowercase() == "readme";
+            let b_is_readme = b.name.to_lowercase() == "readme";
+
+            match (a_is_readme, b_is_readme) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => a.relative_path.cmp(&b.relative_path),
+            }
+        });
+
+        Ok(FileTree { base_path, files })
+    }
+
+    /// Create a FileTree from a single file
+    pub fn from_file(path: &Path) -> std::io::Result<Self> {
+        let absolute_path = path.canonicalize()?;
+        let base_path = absolute_path
+            .parent()
+            .unwrap_or(&absolute_path)
+            .to_path_buf();
+
+        let relative_path = absolute_path
+            .file_name()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| absolute_path.clone());
+
+        let name = absolute_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("untitled")
+            .to_string();
+
+        let files = vec![MarkdownFile {
+            absolute_path,
+            relative_path,
+            name,
+        }];
+
+        Ok(FileTree { base_path, files })
+    }
+
+    /// Get the default file to display (README or first file)
+    pub fn default_file(&self) -> Option<&MarkdownFile> {
+        self.files.first()
+    }
+
+    /// Find a file by its relative path
+    pub fn find_file(&self, relative_path: &str) -> Option<&MarkdownFile> {
+        self.files.iter().find(|f| {
+            f.relative_path.to_string_lossy() == relative_path
+        })
+    }
+
+    /// Check if this is a single file (not directory mode)
+    pub fn is_single_file(&self) -> bool {
+        self.files.len() == 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_from_directory() {
+        let dir = tempdir().unwrap();
+        let readme = dir.path().join("README.md");
+        let guide = dir.path().join("guide.md");
+        let subdir = dir.path().join("docs");
+        fs::create_dir(&subdir).unwrap();
+        let api = subdir.join("api.md");
+
+        fs::write(&readme, "# README").unwrap();
+        fs::write(&guide, "# Guide").unwrap();
+        fs::write(&api, "# API").unwrap();
+
+        let tree = FileTree::from_directory(dir.path()).unwrap();
+
+        assert_eq!(tree.files.len(), 3);
+        // README should be first
+        assert_eq!(tree.files[0].name, "README");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod files;
 pub mod parser;
 pub mod renderer;
 pub mod server;

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -1,6 +1,8 @@
 use pulldown_cmark::{html, Options, Parser};
+use crate::files::FileTree;
 
 const TEMPLATE: &str = include_str!("../../assets/template.html");
+const TEMPLATE_SIDEBAR: &str = include_str!("../../assets/template_sidebar.html");
 const CSS: &str = include_str!("../../assets/github.css");
 
 pub struct HtmlRenderer {
@@ -14,13 +16,82 @@ impl HtmlRenderer {
         }
     }
 
-    /// Render markdown content to full HTML page
+    /// Render markdown content to full HTML page (single file mode)
     pub fn render(&self, markdown: &str) -> String {
         let html_content = self.markdown_to_html(markdown);
 
         TEMPLATE
             .replace("{{TITLE}}", &self.title)
             .replace("{{CONTENT}}", &html_content)
+    }
+
+    /// Render markdown content with sidebar (directory mode)
+    pub fn render_with_sidebar(
+        &self,
+        markdown: &str,
+        file_tree: &FileTree,
+        current_file: Option<&str>,
+    ) -> String {
+        let html_content = self.markdown_to_html(markdown);
+        let sidebar_html = self.build_sidebar(file_tree, current_file);
+
+        TEMPLATE_SIDEBAR
+            .replace("{{TITLE}}", &self.title)
+            .replace("{{SIDEBAR}}", &sidebar_html)
+            .replace("{{CONTENT}}", &html_content)
+    }
+
+    /// Render only the content HTML (for AJAX loading)
+    pub fn render_content(&self, markdown: &str) -> String {
+        self.markdown_to_html(markdown)
+    }
+
+    /// Build sidebar HTML from file tree
+    fn build_sidebar(&self, file_tree: &FileTree, current_file: Option<&str>) -> String {
+        let mut html = String::new();
+
+        // Group files by directory
+        let mut dirs: std::collections::BTreeMap<String, Vec<&crate::files::MarkdownFile>> =
+            std::collections::BTreeMap::new();
+
+        for file in &file_tree.files {
+            let parent = file
+                .relative_path
+                .parent()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default();
+            dirs.entry(parent).or_default().push(file);
+        }
+
+        // Render file tree
+        for (dir, files) in &dirs {
+            if !dir.is_empty() {
+                html.push_str(&format!(
+                    r#"<div class="sidebar-folder">📁 {}</div>"#,
+                    html_escape::encode_text(dir)
+                ));
+            }
+
+            for file in files {
+                let path = file.relative_path.to_string_lossy();
+                let is_current = current_file.map_or(false, |c| c == path);
+                let class = if is_current {
+                    "sidebar-item active"
+                } else {
+                    "sidebar-item"
+                };
+
+                html.push_str(&format!(
+                    r#"<a href="javascript:void(0)" class="{}" data-path="{}" onclick="loadFile('{}')">{}</a>"#,
+                    class,
+                    html_escape::encode_text(&path),
+                    html_escape::encode_text(&path),
+                    html_escape::encode_text(&file.name)
+                ));
+            }
+        }
+
+        html
     }
 
     /// Convert markdown to HTML fragment
@@ -33,7 +104,33 @@ impl HtmlRenderer {
         let parser = Parser::new_ext(markdown, options);
         let mut html_output = String::new();
         html::push_html(&mut html_output, parser);
-        html_output
+
+        // Convert relative .md links to use the viewer
+        self.process_md_links(&html_output)
+    }
+
+    /// Process markdown links to make .md files open in the viewer
+    fn process_md_links(&self, html: &str) -> String {
+        // Simple regex-like replacement for .md links
+        // Convert href="something.md" to onclick handler
+        let mut result = html.to_string();
+
+        // Find and replace .md links
+        let link_pattern = regex::Regex::new(r#"href="([^"]+\.md)""#).ok();
+
+        if let Some(re) = link_pattern {
+            result = re
+                .replace_all(&result, |caps: &regex::Captures| {
+                    let path = &caps[1];
+                    format!(
+                        r#"href="javascript:void(0)" onclick="loadFile('{}')""#,
+                        html_escape::encode_text(path)
+                    )
+                })
+                .to_string();
+        }
+
+        result
     }
 
     /// Get CSS content for serving

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,39 +1,87 @@
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
-        State,
+        Query, State,
     },
     http::{header, HeaderMap, StatusCode},
     response::{Html, IntoResponse, Response},
     routing::get,
-    Router,
+    Json, Router,
 };
-use std::path::PathBuf;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
+use crate::files::FileTree;
 use crate::renderer::html::HtmlRenderer;
 use crate::watcher::watch_file_async;
 
+#[derive(Serialize)]
+pub struct FileInfo {
+    pub path: String,
+    pub name: String,
+    pub is_dir: bool,
+}
+
+#[derive(Serialize)]
+pub struct FileListResponse {
+    pub files: Vec<FileInfo>,
+    pub base_path: String,
+}
+
+#[derive(Deserialize)]
+pub struct ViewQuery {
+    pub file: Option<String>,
+}
+
 pub struct ServerState {
-    pub markdown_path: PathBuf,
+    pub file_tree: FileTree,
     pub title: String,
     pub reload_tx: broadcast::Sender<()>,
 }
 
 impl ServerState {
-    fn render_html(&self) -> String {
-        let content = std::fs::read_to_string(&self.markdown_path).unwrap_or_default();
+    fn render_html(&self, file_path: Option<&str>) -> String {
+        let file = if let Some(path) = file_path {
+            self.file_tree.find_file(path)
+        } else {
+            self.file_tree.default_file()
+        };
+
+        let (content, current_file) = if let Some(f) = file {
+            let content = std::fs::read_to_string(&f.absolute_path).unwrap_or_default();
+            (content, Some(f.relative_path.to_string_lossy().to_string()))
+        } else {
+            ("# No file selected".to_string(), None)
+        };
+
         let renderer = HtmlRenderer::new(&self.title);
-        renderer.render(&content)
+
+        if self.file_tree.is_single_file() {
+            renderer.render(&content)
+        } else {
+            renderer.render_with_sidebar(&content, &self.file_tree, current_file.as_deref())
+        }
+    }
+
+    fn render_content_only(&self, file_path: &str) -> Option<String> {
+        let file = self.file_tree.find_file(file_path)?;
+        let content = std::fs::read_to_string(&file.absolute_path).ok()?;
+        let renderer = HtmlRenderer::new(&self.title);
+        Some(renderer.render_content(&content))
     }
 }
 
-pub async fn start_server(markdown_path: PathBuf, title: &str, port: u16, watch: bool) -> std::io::Result<()> {
+pub async fn start_server(
+    file_tree: FileTree,
+    title: &str,
+    port: u16,
+    watch: bool,
+) -> std::io::Result<()> {
     let (reload_tx, _) = broadcast::channel::<()>(16);
 
     let state = Arc::new(ServerState {
-        markdown_path: markdown_path.clone(),
+        file_tree: file_tree.clone(),
         title: title.to_string(),
         reload_tx: reload_tx.clone(),
     });
@@ -41,16 +89,33 @@ pub async fn start_server(markdown_path: PathBuf, title: &str, port: u16, watch:
     // Start file watcher if watch mode is enabled
     if watch {
         let watch_tx = reload_tx.clone();
-        let watch_path = markdown_path.clone();
-        tokio::spawn(async move {
-            if let Err(e) = watch_file_async(&watch_path, watch_tx).await {
-                eprintln!("Failed to start file watcher: {}", e);
+
+        if file_tree.is_single_file() {
+            // Watch single file
+            if let Some(file) = file_tree.default_file() {
+                let watch_path = file.absolute_path.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = watch_file_async(&watch_path, watch_tx).await {
+                        eprintln!("Failed to start file watcher: {}", e);
+                    }
+                });
             }
-        });
+        } else {
+            // Watch entire directory
+            let watch_path = file_tree.base_path.clone();
+            tokio::spawn(async move {
+                if let Err(e) = crate::watcher::watch_directory_async(&watch_path, watch_tx).await {
+                    eprintln!("Failed to start directory watcher: {}", e);
+                }
+            });
+        }
     }
 
     let app = Router::new()
         .route("/", get(serve_html))
+        .route("/view", get(serve_html))
+        .route("/api/files", get(serve_file_list))
+        .route("/api/content", get(serve_content))
         .route("/assets/github.css", get(serve_css))
         .route("/ws", get(ws_handler))
         .with_state(state);
@@ -75,10 +140,51 @@ pub async fn start_server(markdown_path: PathBuf, title: &str, port: u16, watch:
     Ok(())
 }
 
-async fn serve_html(State(state): State<Arc<ServerState>>) -> (HeaderMap, Html<String>) {
+async fn serve_html(
+    State(state): State<Arc<ServerState>>,
+    Query(query): Query<ViewQuery>,
+) -> (HeaderMap, Html<String>) {
     let mut headers = HeaderMap::new();
     headers.insert(header::CACHE_CONTROL, "no-store".parse().unwrap());
-    (headers, Html(state.render_html()))
+    (headers, Html(state.render_html(query.file.as_deref())))
+}
+
+async fn serve_file_list(State(state): State<Arc<ServerState>>) -> Json<FileListResponse> {
+    let files = state
+        .file_tree
+        .files
+        .iter()
+        .map(|f| FileInfo {
+            path: f.relative_path.to_string_lossy().to_string(),
+            name: f.name.clone(),
+            is_dir: false,
+        })
+        .collect();
+
+    Json(FileListResponse {
+        files,
+        base_path: state.file_tree.base_path.to_string_lossy().to_string(),
+    })
+}
+
+#[derive(Deserialize)]
+pub struct ContentQuery {
+    pub file: String,
+}
+
+async fn serve_content(
+    State(state): State<Arc<ServerState>>,
+    Query(query): Query<ContentQuery>,
+) -> Response {
+    match state.render_content_only(&query.file) {
+        Some(content) => {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::CACHE_CONTROL, "no-store".parse().unwrap());
+            headers.insert(header::CONTENT_TYPE, "text/html; charset=utf-8".parse().unwrap());
+            (headers, content).into_response()
+        }
+        None => (StatusCode::NOT_FOUND, "File not found").into_response(),
+    }
 }
 
 async fn serve_css() -> Response {


### PR DESCRIPTION
## Summary
ディレクトリを指定して複数のMarkdownファイルを閲覧できるモードを追加

## Usage
```bash
mdp .                  # ディレクトリのファイル一覧（ターミナル）
mdp ./docs             # 指定ディレクトリ
mdp -b .               # ブラウザ + サイドバーナビゲーション
mdp -bw .              # ブラウザ + ディレクトリ監視 + ライブリロード
```

## Features
- 📁 サイドバーでファイルツリー表示
- 🔄 Ajaxでファイル切り替え（ページリロードなし）
- 📐 サイドバー幅リサイズ可能
- 🔗 ドキュメント内の.mdリンクをクリックで同一ビューア内で開く
- 👀 ディレクトリ全体の.mdファイル監視
- 🌙 ダークモード対応

## Changes
- `src/files.rs` - 新規: ファイルツリー収集モジュール
- `src/server.rs` - FileTree対応、API追加
- `src/watcher.rs` - ディレクトリ監視追加
- `src/renderer/html.rs` - サイドバー付きレンダリング追加
- `src/main.rs` - ディレクトリ/ファイル両方受付
- `assets/template_sidebar.html` - サイドバー付きテンプレート
- `Cargo.toml` - walkdir, serde, regex追加

Closes #6