### PR TITLE
refactor: Code review, cleanup, and edition 2024 update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "mdp"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 description = "A rich Markdown previewer for the terminal and browser"
-authors = ["Your Name"]
+authors = ["sora-grayscale"]
 license = "MIT"
+repository = "https://github.com/sora-grayscale/mdp"
+homepage = "https://github.com/sora-grayscale/mdp"
+readme = "README.md"
+keywords = ["markdown", "preview", "terminal", "browser", "cli"]
+categories = ["command-line-utilities", "text-processing"]
 
 [dependencies]
 # CLI
@@ -18,7 +24,6 @@ syntect = "5"
 
 # Terminal
 crossterm = "0.27"
-textwrap = "0.16"
 
 # Unicode width for proper alignment
 unicode-width = "0.1"

--- a/README.md
+++ b/README.md
@@ -14,12 +14,17 @@ A rich Markdown previewer for the terminal and browser, written in Rust.
 - Bold, italic, strikethrough text
 - Inline code highlighting
 - Automatic paging with less
+- Watch mode with live reload
 
 ### Browser Mode
 - GitHub-style rendering with CSS
+- Dark/Light theme toggle with system preference detection
 - Live reload on file changes
 - Syntax highlighting (powered by highlight.js)
 - Directory mode with sidebar navigation
+- Collapsible folder tree in sidebar
+- External links open in new tab
+- Auto-shutdown when browser tab closes
 
 ### Planned Features
 - KaTeX math rendering
@@ -37,6 +42,10 @@ cd mdp
 cargo build --release
 sudo cp target/release/mdp /usr/local/bin/
 ```
+
+### From Releases
+
+Download the pre-built binary for your platform from the [Releases](https://github.com/sora-grayscale/mdp/releases) page.
 
 ## Usage
 
@@ -56,7 +65,7 @@ mdp -b ./docs
 # Disable pager (output directly)
 mdp --no-pager README.md
 
-# Specify theme
+# Specify theme (terminal mode)
 mdp --theme light README.md
 
 # Show help
@@ -76,9 +85,22 @@ mdp --help
 
 ## Requirements
 
-- Rust 1.70+
+- Rust 1.85+ (edition 2024)
 - A terminal with 24-bit color support (recommended)
 - `less` or another pager (optional)
+
+## Development
+
+```bash
+# Run tests
+cargo test
+
+# Run with clippy
+cargo clippy --all-targets --all-features -- -D warnings
+
+# Format code
+cargo fmt
+```
 
 ## Similar Projects
 
@@ -91,4 +113,3 @@ mdp --help
 ## License
 
 [MIT](./LICENSE)
-

--- a/src/files.rs
+++ b/src/files.rs
@@ -39,25 +39,25 @@ impl FileTree {
                 continue;
             }
 
-            if let Some(ext) = entry_path.extension() {
-                if ext == "md" || ext == "markdown" {
-                    let relative_path = entry_path
-                        .strip_prefix(&base_path)
-                        .unwrap_or(entry_path)
-                        .to_path_buf();
+            if let Some(ext) = entry_path.extension()
+                && (ext == "md" || ext == "markdown")
+            {
+                let relative_path = entry_path
+                    .strip_prefix(&base_path)
+                    .unwrap_or(entry_path)
+                    .to_path_buf();
 
-                    let name = entry_path
-                        .file_stem()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or("untitled")
-                        .to_string();
+                let name = entry_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("untitled")
+                    .to_string();
 
-                    files.push(MarkdownFile {
-                        absolute_path: entry_path.to_path_buf(),
-                        relative_path,
-                        name,
-                    });
-                }
+                files.push(MarkdownFile {
+                    absolute_path: entry_path.to_path_buf(),
+                    relative_path,
+                    name,
+                });
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ fn main() {
     } else if args.watch {
         // Terminal watch mode (single file only for now)
         if let Some(file) = file_tree.default_file() {
-            run_terminal_watch_mode(&file.absolute_path, &args.theme, args.no_pager);
+            run_terminal_watch_mode(&file.absolute_path, &args.theme);
         }
     } else {
         // Normal terminal mode
@@ -175,11 +175,10 @@ fn run_terminal_mode(file_path: &PathBuf, theme: &str, no_pager: bool) {
     }
 }
 
-fn run_terminal_watch_mode(file_path: &PathBuf, theme: &str, _no_pager: bool) {
+fn run_terminal_watch_mode(file_path: &PathBuf, theme: &str) {
     use crossterm::{
-        cursor,
+        ExecutableCommand, cursor,
         terminal::{self, ClearType},
-        ExecutableCommand,
     };
 
     let (tx, mut rx) = broadcast::channel::<()>(16);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -383,7 +383,6 @@ fn parse_element(events: &[Event], start: usize) -> (Option<Element>, usize) {
             let mut headers = Vec::new();
             let mut rows = Vec::new();
             let mut index = start + 1;
-            let mut _in_head = false;
             let mut current_row = Vec::new();
             let mut current_cell = String::new();
 
@@ -393,13 +392,11 @@ fn parse_element(events: &[Event], start: usize) -> (Option<Element>, usize) {
                         break;
                     }
                     Event::Start(Tag::TableHead) => {
-                        _in_head = true;
                         current_row = Vec::new();
                     }
                     Event::End(TagEnd::TableHead) => {
                         // TableHead contains cells directly without TableRow in pulldown-cmark 0.10
                         headers = current_row.clone();
-                        _in_head = false;
                     }
                     Event::Start(Tag::TableRow) => {
                         current_row = Vec::new();

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -1,5 +1,5 @@
 use crate::files::FileTree;
-use pulldown_cmark::{html, Options, Parser};
+use pulldown_cmark::{Options, Parser, html};
 
 const TEMPLATE: &str = include_str!("../../assets/template.html");
 const TEMPLATE_SIDEBAR: &str = include_str!("../../assets/template_sidebar.html");

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,16 +1,16 @@
 use axum::{
+    Json, Router,
     extract::{
-        ws::{Message, WebSocket, WebSocketUpgrade},
         Query, State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
     },
-    http::{header, HeaderMap, StatusCode},
+    http::{HeaderMap, StatusCode, header},
     response::{Html, IntoResponse, Response},
     routing::get,
-    Json, Router,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::broadcast;
 
 use crate::files::FileTree;
@@ -221,10 +221,7 @@ async fn ws_handler(ws: WebSocketUpgrade, State(state): State<Arc<ServerState>>)
 
 async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
     // Increment connection count
-    let prev_count = state.connection_count.fetch_add(1, Ordering::SeqCst);
-    if prev_count == 0 {
-        // First connection or reconnection after all disconnected
-    }
+    state.connection_count.fetch_add(1, Ordering::SeqCst);
 
     let mut rx = state.reload_tx.subscribe();
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,5 +1,5 @@
 use notify::RecursiveMode;
-use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
+use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
 use std::path::Path;
 use std::sync::mpsc::channel;
 use std::time::Duration;
@@ -136,12 +136,10 @@ pub async fn watch_directory_async<P: AsRef<Path>>(
                 Ok(Ok(events)) => {
                     // Filter for markdown files only
                     let md_changed = events.iter().any(|e| {
-                        if e.kind == DebouncedEventKind::Any {
-                            if let Some(ext) = e.path.extension() {
-                                return ext == "md" || ext == "markdown";
-                            }
-                        }
-                        false
+                        e.kind == DebouncedEventKind::Any
+                            && e.path
+                                .extension()
+                                .is_some_and(|ext| ext == "md" || ext == "markdown")
                     });
 
                     if md_changed {


### PR DESCRIPTION
## Summary
- Update Cargo.toml metadata (authors, repository, homepage, keywords)
- Remove unused `textwrap` dependency
- Update to Rust edition 2024
- Use let chains in `files.rs` (edition 2024 feature)
- Use `is_some_and` in `watcher.rs`
- Remove unused `_in_head` variable in `parser.rs`
- Remove dead code (empty if block) in `server.rs`
- Remove unused `_no_pager` parameter in `main.rs`
- Update README.md with new features and Rust 1.85+ requirement

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [x] Build succeeds with edition 2024