### PR TITLE
feat: Add table of contents generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A rich Markdown previewer for the terminal and browser, written in Rust.
 - Horizontal rules
 - Bold, italic, strikethrough text
 - Inline code highlighting
+- Footnotes support
+- Table of contents generation (`--toc`)
 - Automatic paging with less
 - Watch mode with live reload
 
@@ -24,13 +26,14 @@ A rich Markdown previewer for the terminal and browser, written in Rust.
 - Directory mode with sidebar navigation
 - Collapsible folder tree in sidebar
 - External links open in new tab
+- Footnotes support
+- Table of contents generation (`--toc`)
 - Auto-shutdown when browser tab closes
 
 ### Planned Features
 - KaTeX math rendering
 - Mermaid diagram support
 - Image display (iTerm2/Kitty protocol)
-- Table of contents generation
 
 ## Installation
 
@@ -65,6 +68,12 @@ mdp -b ./docs
 # Disable pager (output directly)
 mdp --no-pager README.md
 
+# Show table of contents
+mdp --toc README.md
+
+# Browser mode with TOC
+mdp -b --toc README.md
+
 # Specify theme (terminal mode)
 mdp --theme light README.md
 
@@ -81,7 +90,7 @@ mdp --help
 | `-p, --port <PORT>` | Port for browser mode (default: 3000) |
 | `--theme <THEME>` | Theme: dark or light (default: dark) |
 | `--no-pager` | Disable pager, output directly to stdout |
-| `--toc` | Show table of contents (not yet implemented) |
+| `--toc` | Show table of contents at document top |
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Add `--toc` option to display table of contents at document top
- Terminal mode: TOC with bullet points and proper indentation
- Browser mode: TOC with clickable anchor links to headings
- Add `TocEntry` struct and `generate_toc()` function in parser
- Update README with new feature documentation

Closes #23

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [x] Terminal: `mdp --toc test.md` shows TOC at top
- [x] Browser: `mdp -b --toc test.md` shows clickable TOC
- [x] Heading anchors work correctly (with duplicate handling)