### PR TITLE
feat: Auto-update sidebar when files are added/removed

### DIFF
--- a/assets/template_sidebar.html
+++ b/assets/template_sidebar.html
@@ -505,6 +505,67 @@
             }
         }
 
+        // Update sidebar from API
+        async function updateSidebar() {
+            try {
+                const response = await fetch('/api/files');
+                if (!response.ok) throw new Error('Failed to fetch files');
+
+                const data = await response.json();
+                const sidebarContent = document.querySelector('.sidebar-content');
+
+                // Group files by directory
+                const dirs = {};
+                data.files.forEach(file => {
+                    const lastSlash = file.path.lastIndexOf('/');
+                    const dir = lastSlash === -1 ? '' : file.path.substring(0, lastSlash);
+                    if (!dirs[dir]) dirs[dir] = [];
+                    dirs[dir].push(file);
+                });
+
+                // Build sidebar HTML
+                let html = '';
+                const sortedDirs = Object.keys(dirs).sort();
+
+                sortedDirs.forEach(dir => {
+                    const files = dirs[dir];
+                    if (dir === '') {
+                        // Root level files
+                        files.forEach(file => {
+                            const isActive = file.path === currentFile;
+                            html += `<a href="javascript:void(0)" class="sidebar-item root-item${isActive ? ' active' : ''}" data-path="${escapeHtml(file.path)}" onclick="loadFile('${escapeHtml(file.path)}')">${icons.file}<span class="sidebar-item-name">${escapeHtml(file.name)}</span></a>`;
+                        });
+                    } else {
+                        // Files in a folder
+                        const folderId = dir.replace(/\//g, '_').replace(/\\/g, '_');
+                        const isCollapsed = collapsedFolders[folderId] ? ' collapsed' : '';
+                        html += `<div class="sidebar-folder${isCollapsed}" data-folder="${escapeHtml(folderId)}">
+                            <div class="sidebar-folder-header" onclick="toggleFolder('${escapeHtml(folderId)}')">
+                                ${icons.chevron}
+                                <span class="sidebar-folder-name">${escapeHtml(dir)}</span>
+                            </div>
+                            <div class="sidebar-folder-items">`;
+                        files.forEach(file => {
+                            const isActive = file.path === currentFile;
+                            html += `<a href="javascript:void(0)" class="sidebar-item${isActive ? ' active' : ''}" data-path="${escapeHtml(file.path)}" onclick="loadFile('${escapeHtml(file.path)}')">${icons.file}<span class="sidebar-item-name">${escapeHtml(file.name)}</span></a>`;
+                        });
+                        html += '</div></div>';
+                    }
+                });
+
+                sidebarContent.innerHTML = html;
+            } catch (e) {
+                console.error('Failed to update sidebar:', e);
+            }
+        }
+
+        // HTML escape helper
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
         // Expand the parent folder of a file path
         function expandParentFolder(path) {
             // Get the directory part of the path
@@ -598,6 +659,9 @@
                         } else {
                             window.location.reload();
                         }
+                    } else if (event.data === 'tree-update') {
+                        showIndicator('Updating sidebar...', false);
+                        updateSidebar();
                     }
                 };
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,9 +1,13 @@
 use notify::RecursiveMode;
 use notify_debouncer_mini::{DebouncedEventKind, new_debouncer};
+use std::collections::HashSet;
 use std::path::Path;
+use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::time::Duration;
 use tokio::sync::broadcast;
+
+use crate::server::{ServerState, WsMessage};
 
 /// Watch a file for changes and send notifications
 pub fn watch_file<P: AsRef<Path>>(path: P, tx: broadcast::Sender<()>) -> notify::Result<()> {
@@ -49,7 +53,7 @@ pub fn watch_file<P: AsRef<Path>>(path: P, tx: broadcast::Sender<()>) -> notify:
 /// Watch a file asynchronously using tokio
 pub async fn watch_file_async<P: AsRef<Path>>(
     path: P,
-    tx: broadcast::Sender<()>,
+    tx: broadcast::Sender<WsMessage>,
 ) -> notify::Result<()> {
     let path = path.as_ref().to_path_buf();
 
@@ -83,7 +87,7 @@ pub async fn watch_file_async<P: AsRef<Path>>(
                     for event in events {
                         if event.kind == DebouncedEventKind::Any {
                             println!("File changed, reloading...");
-                            let _ = tx.send(());
+                            let _ = tx.send(WsMessage::Reload);
                         }
                     }
                 }
@@ -103,18 +107,30 @@ pub async fn watch_file_async<P: AsRef<Path>>(
     Ok(())
 }
 
-/// Watch a directory recursively for .md file changes
-pub async fn watch_directory_async<P: AsRef<Path>>(
+/// Watch a directory recursively for .md file changes with tree update support
+pub async fn watch_directory_with_tree_update<P: AsRef<Path>>(
     path: P,
-    tx: broadcast::Sender<()>,
+    tx: broadcast::Sender<WsMessage>,
+    state: Arc<ServerState>,
 ) -> notify::Result<()> {
     let path = path.as_ref().to_path_buf();
 
     println!("Watching directory for changes: {}", path.display());
 
+    // Get initial file paths for comparison (detects renames, not just count changes)
+    let initial_paths: HashSet<String> = {
+        let tree = state.file_tree.read().await;
+        tree.files
+            .iter()
+            .map(|f| f.relative_path.to_string_lossy().to_string())
+            .collect()
+    };
+
     // Spawn blocking task for directory watching
+    let rt = tokio::runtime::Handle::current();
     tokio::task::spawn_blocking(move || {
         let (debounce_tx, debounce_rx) = channel();
+        let mut last_paths = initial_paths;
 
         // Create a debouncer with 200ms delay
         let mut debouncer = match new_debouncer(Duration::from_millis(200), debounce_tx) {
@@ -135,16 +151,46 @@ pub async fn watch_directory_async<P: AsRef<Path>>(
             match debounce_rx.recv() {
                 Ok(Ok(events)) => {
                     // Filter for markdown files only
-                    let md_changed = events.iter().any(|e| {
-                        e.kind == DebouncedEventKind::Any
-                            && e.path
-                                .extension()
-                                .is_some_and(|ext| ext == "md" || ext == "markdown")
+                    let md_events: Vec<_> = events
+                        .iter()
+                        .filter(|e| {
+                            e.kind == DebouncedEventKind::Any
+                                && e.path
+                                    .extension()
+                                    .is_some_and(|ext| ext == "md" || ext == "markdown")
+                        })
+                        .collect();
+
+                    if md_events.is_empty() {
+                        continue;
+                    }
+
+                    // Rebuild file tree and get new file paths
+                    let new_paths: HashSet<String> = rt.block_on(async {
+                        if let Err(e) = state.rebuild_file_tree().await {
+                            eprintln!("Failed to rebuild file tree: {}", e);
+                            return last_paths.clone();
+                        }
+                        let tree = state.file_tree.read().await;
+                        tree.files
+                            .iter()
+                            .map(|f| f.relative_path.to_string_lossy().to_string())
+                            .collect()
                     });
 
-                    if md_changed {
+                    // Check if file paths changed (handles add, remove, and rename)
+                    if new_paths != last_paths {
+                        println!(
+                            "File tree changed ({} -> {} files), updating sidebar...",
+                            last_paths.len(),
+                            new_paths.len()
+                        );
+                        let _ = tx.send(WsMessage::TreeUpdate);
+                        last_paths = new_paths;
+                    } else {
+                        // Just content changed
                         println!("Markdown file changed, reloading...");
-                        let _ = tx.send(());
+                        let _ = tx.send(WsMessage::Reload);
                     }
                 }
                 Ok(Err(e)) => {


### PR DESCRIPTION
## Summary
- ディレクトリモード（`-bw`）で.mdファイルが追加/削除された際に、サイドバーを自動更新
- `WsMessage`列挙型でReloadとTreeUpdateを区別
- `RwLock<FileTree>`で動的なファイルツリー更新をサポート
- WebSocket経由で`tree-update`メッセージを送信し、クライアント側でサイドバーを再構築

## Changes
- `src/server.rs`: `WsMessage`追加、`file_tree`を`RwLock`化、`rebuild_file_tree()`追加
- `src/watcher.rs`: `watch_directory_with_tree_update()`関数追加
- `assets/template_sidebar.html`: `updateSidebar()` JavaScript関数追加

## Test plan
- [x] `mdp -bw /path/to/dir` でディレクトリを開く
- [x] 新しい.mdファイルを作成 → サイドバーに自動追加される
- [x] .mdファイルを削除 → サイドバーから自動削除される
- [x] ファイル内容変更 → 従来通りコンテンツがリロードされる

Closes #29