### PR TITLE
feat: Add --sidebar option for single file mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,10 @@ struct Args {
     #[arg(long)]
     toc: bool,
 
+    /// Show sidebar with related markdown files (for single file mode)
+    #[arg(short, long)]
+    sidebar: bool,
+
     /// Theme (dark or light)
     #[arg(long, default_value = "dark")]
     theme: String,
@@ -93,11 +97,22 @@ fn main() {
             );
         }
 
-        match FileTree::from_file(&args.path) {
-            Ok(tree) => tree,
-            Err(e) => {
-                eprintln!("Error: Failed to read file: {}", e);
-                process::exit(1);
+        // Use context mode if sidebar option is enabled
+        if args.sidebar {
+            match FileTree::from_file_with_context(&args.path) {
+                Ok(tree) => tree,
+                Err(e) => {
+                    eprintln!("Error: Failed to scan directory: {}", e);
+                    process::exit(1);
+                }
+            }
+        } else {
+            match FileTree::from_file(&args.path) {
+                Ok(tree) => tree,
+                Err(e) => {
+                    eprintln!("Error: Failed to read file: {}", e);
+                    process::exit(1);
+                }
             }
         }
     };


### PR DESCRIPTION
## Summary
- 単一ファイル指定時に `-s/--sidebar` オプションでサイドバーを表示
- 親ディレクトリ以下の関連mdファイルをサイドバーに表示
- 指定ファイルを最初に、次にREADME、その後アルファベット順でソート

## Changes
- `src/main.rs`: `--sidebar` / `-s` CLIオプション追加
- `src/files.rs`: `FileTree::from_file_with_context()` 追加

## Usage
```bash
# 単一ファイルをサイドバー付きで開く
mdp -bs README.md

# 従来の動作（サイドバーなし）
mdp -b README.md
```

## Test plan
- [x] `mdp -bs /path/to/file.md` でサイドバーに関連ファイルが表示される
- [x] 指定したファイルがサイドバーの最初に表示される
- [x] 既存の動作（`mdp -b file.md`, `mdp -b ./dir`）に影響なし

Closes #16