### PR TITLE
fix: Address code review issues (batch 1)

### DIFF
--- a/src/renderer/terminal.rs
+++ b/src/renderer/terminal.rs
@@ -289,7 +289,13 @@ impl TerminalRenderer {
             "base16-ocean.dark"
         };
 
-        let theme = &self.theme_set.themes[syntax_theme];
+        // Get theme with fallback to first available theme
+        let theme = self
+            .theme_set
+            .themes
+            .get(syntax_theme)
+            .or_else(|| self.theme_set.themes.values().next())
+            .expect("No themes available in ThemeSet");
 
         // Find syntax for the language
         let syntax = language


### PR DESCRIPTION
## Summary
- #42: Prevent symlink loops with `follow_links(false)` in walkdir
- #43: Improve pager error handling with proper fallback to stdout
- #44: Fix port help text to mention auto-increment behavior
- #45: Replace `block_on` with channel-based async to avoid potential deadlock
- #50: Add theme fallback when configured theme not found
- #51: Normalize paths in `find_file` for cross-platform compatibility
- #59: Reduce lock duration by releasing RwLock before I/O operations

## Test plan
- [x] `cargo test` - all tests pass
- [x] `cargo clippy` - no warnings
- [x] `cargo fmt` - formatted

Closes #42, closes #43, closes #44, closes #45, closes #50, closes #51, closes #59