### PR TITLE
ci: gracefully handle version bump PR merge failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,4 +228,4 @@ jobs:
             --body "Automated version bump to ${{ needs.version.outputs.version }}" \
             --base main \
             --head "$BRANCH"
-          gh pr merge "$BRANCH" --admin --rebase --delete-branch
+          gh pr merge "$BRANCH" --rebase --delete-branch || echo "PR created. Will need manual merge (CI checks required)."


### PR DESCRIPTION
## Summary
- version bump PRのマージ失敗時に `--admin` の代わりに `|| fallback` を使用
- GITHUB_TOKENにadmin権限がない場合でもリリース/ビルドが正常に完了